### PR TITLE
Sistema multirobot permite todos los robots de Robotics

### DIFF
--- a/multi_robot_gazebo/config/robots_empty_world.yaml
+++ b/multi_robot_gazebo/config/robots_empty_world.yaml
@@ -4,23 +4,12 @@ robots:
     y_pose: 0.0
     z_pose: 0.01
     yaw: 0.0
+    urdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/urdf/turtlebot3_burger.urdf"
+    sdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/models/turtlebot3_burger/model.sdf"
   - name: tb2
     x_pose: 1.0
     y_pose: 1.0
     z_pose: 0.01
     yaw: 0.0
-  - name: tb3
-    x_pose: -1.0
-    y_pose: 1.0
-    z_pose: 0.01
-    yaw: 0.0
-  - name: tb4
-    x_pose: -1.0
-    y_pose: -1.0
-    z_pose: 0.01
-    yaw: 0.0
-  - name: tb5
-    x_pose: 1.0
-    y_pose: -1.0
-    z_pose: 0.01
-    yaw: 0.0
+    urdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/urdf/turtlebot3_burger.urdf"
+    sdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/models/turtlebot3_burger/model.sdf"

--- a/multi_robot_gazebo/config/robots_world.yaml
+++ b/multi_robot_gazebo/config/robots_world.yaml
@@ -4,8 +4,19 @@ robots:
     y_pose: -0.5
     z_pose: 0.01
     yaw: 0.0
+    urdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/urdf/turtlebot3_burger.urdf"
+    sdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/models/turtlebot3_burger/model.sdf"
   - name: tb2
     x_pose: -1.5
     y_pose: 0.5
     z_pose: 0.01
     yaw: 0.0
+    urdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/urdf/turtlebot3_waffle.urdf"
+    sdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/models/turtlebot3_waffle/model.sdf"
+  - name: tb3
+    x_pose: 1.5
+    y_pose: 0.5
+    z_pose: 0.01
+    yaw: 0.0
+    urdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/urdf/turtlebot3_waffle_pi.urdf"
+    sdf_path: "/home/rov-robot/colcon_ws/src/turtlebot3_simulations/turtlebot3_gazebo/models/turtlebot3_waffle_pi/model.sdf"

--- a/multi_robot_gazebo/launch/multi_robot_empty_world.launch.py
+++ b/multi_robot_gazebo/launch/multi_robot_empty_world.launch.py
@@ -57,11 +57,8 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'use_sim_time': use_sim_time,
-                'x_pose': TextSubstitution(text=str(robot['x_pose'])),
-                'y_pose': TextSubstitution(text=str(robot['y_pose'])),
-                'z_pose': TextSubstitution(text=str(robot['z_pose'])),
-                'robot_name': robot['name'],
                 'robot_namespace': robot['name'],
+                'urdf_path': robot['urdf_path'],
             }.items()
         )
 
@@ -71,6 +68,7 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'use_sim_time': use_sim_time,
+                'urdf_path': robot['sdf_path'],
                 'x_pose': TextSubstitution(text=str(robot['x_pose'])),
                 'y_pose': TextSubstitution(text=str(robot['y_pose'])),
                 'z_pose': TextSubstitution(text=str(robot['z_pose'])),

--- a/multi_robot_gazebo/launch/multi_robot_world.launch.py
+++ b/multi_robot_gazebo/launch/multi_robot_world.launch.py
@@ -57,11 +57,8 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'use_sim_time': use_sim_time,
-                'x_pose': TextSubstitution(text=str(robot['x_pose'])),
-                'y_pose': TextSubstitution(text=str(robot['y_pose'])),
-                'z_pose': TextSubstitution(text=str(robot['z_pose'])),
-                'robot_name': robot['name'],
                 'robot_namespace': robot['name'],
+                'urdf_path': robot['urdf_path'],
             }.items()
         )
 
@@ -71,6 +68,7 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'use_sim_time': use_sim_time,
+                'urdf_path': robot['sdf_path'],
                 'x_pose': TextSubstitution(text=str(robot['x_pose'])),
                 'y_pose': TextSubstitution(text=str(robot['y_pose'])),
                 'z_pose': TextSubstitution(text=str(robot['z_pose'])),

--- a/multi_robot_gazebo/launch/robots_states_publishers.launch.py
+++ b/multi_robot_gazebo/launch/robots_states_publishers.launch.py
@@ -9,12 +9,12 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
+    
+    urdf_path = LaunchConfiguration('urdf_path', default=os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'urdf', 'turtlebot3_burger.urdf'))
 
-    urdf_file_name = 'turtlebot3_burger.urdf'
-    urdf_path = os.path.join(
-        get_package_share_directory('turtlebot3_gazebo'),
-        'urdf',
-        urdf_file_name)
+    declare_urdf_path = DeclareLaunchArgument(
+        'urdf_path', default_value=os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'urdf', 'turtlebot3_burger.urdf'),
+        description='Urdf path of the robot')
 
     robot_namespace = LaunchConfiguration('robot_namespace', default='tb')
 
@@ -37,6 +37,7 @@ def generate_launch_description():
 
     ld = LaunchDescription()
 
+    ld.add_action(declare_urdf_path)
     ld.add_action(declare_robot_namespace)
     ld.add_action(turtlebot_state_publisher)
 

--- a/multi_robot_gazebo/launch/spawn_robots.launch.py
+++ b/multi_robot_gazebo/launch/spawn_robots.launch.py
@@ -9,21 +9,18 @@ from launch_ros.actions import Node
 
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time', default='false')
-
-    model_folder = 'turtlebot3_burger'
-    urdf_path = os.path.join(
-        get_package_share_directory('turtlebot3_gazebo'),
-        'models',
-        model_folder,
-        'model.sdf'
-    )
-
+    urdf_path = LaunchConfiguration('urdf_path', 
+                        default=os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'models', 'turtlebot3_burger', 'model.sdf'))
     robot_namespace = LaunchConfiguration('robot_namespace', default='tb')
     robot_name = LaunchConfiguration('robot_name', default='tb')
     x_pose = LaunchConfiguration('x_pose', default='0.0')
     y_pose = LaunchConfiguration('y_pose', default='0.0')
     z_pose = LaunchConfiguration('z_pose', default='0.01')
     yaw = LaunchConfiguration('yaw', default='0.0')
+
+    declare_urdf_path = DeclareLaunchArgument(
+        'urdf_path', default_value=os.path.join(get_package_share_directory('turtlebot3_gazebo'), 'models', 'turtlebot3_burger', 'model.sdf'),
+        description='Urdf path of the robot')
 
     declare_robot_namespace = DeclareLaunchArgument(
         'robot_namespace', default_value='tb',
@@ -67,6 +64,7 @@ def generate_launch_description():
 
     ld = LaunchDescription()
 
+    ld.add_action(declare_urdf_path)
     ld.add_action(declare_robot_namespace)
     ld.add_action(declare_robot_name)
     ld.add_action(declare_x_pose)


### PR DESCRIPTION
# Descripción
En el mundo de la industria las empresas no poseen robots de un solo modelo sino que suelen tener diferentes modelos para que pueda realizar diferentes actividades. Extender el sistema para que soporte una gran infraestructura es crucial para un poder cumplir con las expectativas de las industrias. 

# Problema Solucionado
Emplear un solo tipo de robot es un aventura complicada para un sistema debido a que tiene que incorporar n robots de n modelos diferentes. Por lo que se actualizo el sistema para que pueda permitir el ingreso de diferentes modelos de robots sin tener problemas.

# Comprobación de cambios
- Ingresar N robots de N modelos diferentes.
- La navegación autonoma funciona sin problema alguno.
- Ingresar N robots del mismo modelo.
- Topics dependientes de cada modelo, no genera topics de camara para el Burger sino solo para el Waffle o Waffle Pi que posee una cámara.

# Capturas de funcionalidad
### Ingresar N robots de N modelos diferentes.
[Screencast from 03-16-2024 12:38:10 PM.webm](https://github.com/iesusdavila/multi_robot/assets/93739894/d9b22f25-62b8-44d9-8227-3db96e4ffa04)

### Navegación autonoma funciona sin problema alguno.
[Screencast from 03-16-2024 12:39:50 PM.webm](https://github.com/iesusdavila/multi_robot/assets/93739894/15e86e71-fcd5-42a8-b2a8-9a999328eeb9)

### Ingresar N robots del mismo modelo.
[Screencast from 03-16-2024 12:41:52 PM.webm](https://github.com/iesusdavila/multi_robot/assets/93739894/0394c483-1400-480a-ad65-0aa39b5fbfc6)

### Topics dependientes de cada modelo

- tb1: Burger
- tb2: Waffle
- tb3: Waffle Pi

![image](https://github.com/iesusdavila/multi_robot/assets/93739894/e679a84e-10b3-4f79-a14c-0dbf4011cd27)
